### PR TITLE
Pretty big refactor, make more Pythonic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ver=1.2
+ver=1.3
 
 
 if [ ! -d dist ]; then
@@ -10,9 +10,7 @@ fi
 ARCHIVE=redshift-advanced-monitoring-$ver.zip
 
 # add required dependencies
-if [ ! -d lib/pg8000 ]; then
-	pip install pg8000 -t lib
-fi
+pip install -r requirements -t lib
 
 # bin the old zipfile
 if [ -f dist/$ARCHIVE ]; then

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -28,7 +28,7 @@ import pg8000
 __version__ = "1.3"
 
 logging.basicConfig(format='%(levelname) -10s %(asctime)s %(module)s at line %(lineno)d: %(message)s')
-logger = logging.getLogger('interval')
+logger = logging.getLogger('redshift-monitoring')
 
 
 # Configuration

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -94,12 +94,12 @@ class Reporter(object):
                 total_rows += tbl_rows
 
         if number_tables_skew > 0:
-            avg_skew_ratio = total_skew_ratio / number_tables_skew
+            avg_skew_ratio = total_skew_ratio / float(number_tables_skew)
         else:
             avg_skew_ratio = 0
 
         if number_tables_skew_sort > 0:
-            avg_skew_sort_ratio = total_skew_sort_ratio / number_tables_skew_sort
+            avg_skew_sort_ratio = total_skew_sort_ratio / float(number_tables_skew_sort)
         else:
             avg_skew_sort_ratio = 0
 
@@ -199,6 +199,7 @@ class Reporter(object):
 
     def run_external_commands(self, command_set_type, file_name, cursor):
         if not os.path.exists(file_name):
+            logger.error("File {} does not exit.".format(file_name))
             return []
 
         try:
@@ -206,6 +207,7 @@ class Reporter(object):
         except ValueError as e:
             # handle a malformed user query set gracefully
             if e.message == "No JSON object could be decoded":
+                logger.error(e.message + " in {}".format(file_name))
                 return []
             else:
                 raise
@@ -225,6 +227,7 @@ class Reporter(object):
             try:
                 value = cursor.fetchone()[0]
             except pg8000.core.ProgrammingError:
+                logger.info("No values fetched for commamnd {}".format(command['name']))
                 value = None
 
             if value is None:
@@ -301,7 +304,7 @@ def configure():
         logger.setLevel(logging.INFO)
 
     for k, v in attr.asdict(reporter).items():
-        if v is None or not v:
+        if not v:
             logger.warning("Parameter {} is unset".format(k))
 
     return reporter

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -12,6 +12,7 @@
 import sys
 import os
 # add the lib directory to the path
+from copy import deepcopy
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "lib"))
 
@@ -273,7 +274,7 @@ class Reporter(object):
     def gather_service_class_stats(self, cursor):
         metrics = []
         poll_ts = datetime.datetime.utcnow()
-        _ = self.run_command(cursor, '''SELECT service_class, num_queued_queries, num_executing_queries 
+        self.run_command(cursor, '''SELECT service_class, num_queued_queries, num_executing_queries 
                                             FROM stv_wlm_service_class_state w WHERE w.service_class >= 6 ORDER BY 1
                                     ''')
         service_class_info = cursor.fetchall()
@@ -283,13 +284,13 @@ class Reporter(object):
                              'Dimensions': [{'Name': self.environment, 'Value': self.cluster}],
                              'Timestamp': poll_ts,
                              'Value': service_class[1]}
-            metrics.append(queued_metric.copy())
+            metrics.append(deepcopy(queued_metric))
 
             executing_metric = {'MetricName': 'ServiceClass%s-Executing' % service_class[0],
                                 'Dimensions': [{'Name': self.environment, 'Value': self.cluster}],
                                 'Timestamp': poll_ts,
                                 'Value': service_class[2]}
-            metrics.append(executing_metric.copy())
+            metrics.append(deepcopy(executing_metric))
 
         return metrics
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,11 @@
+attrs==17.2.0
+boto3==1.4.6
+botocore==1.6.7
+click==6.7
+docutils==0.14
+futures==3.1.1
+jmespath==0.9.3
 pg8000==1.10.5
+python-dateutil==2.6.1
+s3transfer==0.1.10
+six==1.10.0


### PR DESCRIPTION
As we like monitoring Redshift, we might as well use some of the tools provided by the AWS team, this is basically a rewrite of the tool with all functionality preserved. I'm still unclear in some of the original design choices, they are likely a result of running this in AWS Lambda. After we are happy with this I'd like to make a PR upstream.

+ Wrap CloudWatch reporting into a class
+ More concise parameter setting
+ Logging with parametrised log levels
+ Except named exceptions
+ Uppercase environment vars
+ Align variable names
+ Add region_name to client calls
+ Allow for running in lambda as well as not